### PR TITLE
Capture Java annotations in class and method metadata

### DIFF
--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -1188,7 +1188,7 @@ class DefinitionProcessor:
 
                 # Handle Java method overloading with parameter types
                 method_qualified_name = None
-                method_annotations: list[str] | None = None
+                method_annotations: list[dict[str, Any]] | None = None
                 if language == "java":
                     method_info = extract_java_method_info(method_node)
                     method_name = method_info.get("name")

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -23,7 +23,7 @@ from .cpp_utils import (
     is_cpp_exported,
 )
 from .import_processor import ImportProcessor
-from .java_utils import extract_java_method_info
+from .java_utils import extract_java_class_info, extract_java_method_info
 from .lua_utils import extract_lua_assigned_name
 from .python_utils import resolve_class_name
 from .rust_utils import build_rust_module_path, extract_rust_impl_target
@@ -1068,11 +1068,18 @@ class DefinitionProcessor:
                 "qualified_name": class_qn,
                 "name": class_name,
                 "decorators": decorators,
+                "annotations": [],
+                "modifiers": [],
                 "start_line": class_node.start_point[0] + 1,
                 "end_line": class_node.end_point[0] + 1,
                 "docstring": self._get_docstring(class_node),
                 "is_exported": is_exported,
             }
+
+            if language == "java":
+                java_class_info = extract_java_class_info(class_node)
+                class_props["annotations"] = java_class_info.get("annotations", [])
+                class_props["modifiers"] = java_class_info.get("modifiers", [])
             # Determine the correct node type based on the AST node type
             if class_node.type == "interface_declaration":
                 node_type = "Interface"
@@ -1181,10 +1188,12 @@ class DefinitionProcessor:
 
                 # Handle Java method overloading with parameter types
                 method_qualified_name = None
+                method_annotations: list[str] | None = None
                 if language == "java":
                     method_info = extract_java_method_info(method_node)
                     method_name = method_info.get("name")
                     parameters = method_info.get("parameters", [])
+                    method_annotations = method_info.get("annotations", [])
                     if method_name:
                         if parameters:
                             # Create method signature with parameter types for overloading
@@ -1207,6 +1216,7 @@ class DefinitionProcessor:
                     language,
                     self._extract_decorators,
                     method_qualified_name,
+                    method_annotations,
                 )
 
                 # Note: OVERRIDES relationships will be processed later after all methods are collected

--- a/codebase_rag/parsers/java_utils.py
+++ b/codebase_rag/parsers/java_utils.py
@@ -10,6 +10,13 @@ from .utils import safe_decode_text
 DELIMITER_TOKENS = ["(", ")", ","]
 
 
+class JavaAnnotationInfo(TypedDict):
+    """Type definition for Java annotation information."""
+
+    name: str | None
+    arguments: list[str]
+
+
 class JavaClassInfo(TypedDict):
     """Type definition for Java class information."""
 
@@ -19,7 +26,7 @@ class JavaClassInfo(TypedDict):
     interfaces: list[str]
     modifiers: list[str]
     type_parameters: list[str]
-    annotations: list[str]
+    annotations: list[JavaAnnotationInfo]
 
 
 class JavaMethodInfo(TypedDict):
@@ -31,7 +38,7 @@ class JavaMethodInfo(TypedDict):
     parameters: list[str]
     modifiers: list[str]
     type_parameters: list[str]
-    annotations: list[str]
+    annotations: list[JavaAnnotationInfo]
 
 
 class JavaFieldInfo(TypedDict):
@@ -40,14 +47,7 @@ class JavaFieldInfo(TypedDict):
     name: str | None
     type: str | None
     modifiers: list[str]
-    annotations: list[str]
-
-
-class JavaAnnotationInfo(TypedDict):
-    """Type definition for Java annotation information."""
-
-    name: str | None
-    arguments: list[str]
+    annotations: list[JavaAnnotationInfo]
 
 
 def extract_java_package_name(package_node: Node) -> str | None:
@@ -141,6 +141,7 @@ def extract_java_class_info(class_node: Node) -> JavaClassInfo:
         - interfaces: List of implemented interface names
         - modifiers: List of access modifiers
         - type_parameters: List of generic type parameters
+        - annotations: List of annotation metadata dictionaries
     """
     if class_node.type not in [
         "class_declaration",
@@ -230,9 +231,9 @@ def extract_java_class_info(class_node: Node) -> JavaClassInfo:
                     if modifier:
                         info["modifiers"].append(modifier)
                 elif modifier_child.type == "annotation":
-                    annotation = safe_decode_text(modifier_child)
-                    if annotation:
-                        info["annotations"].append(annotation)
+                    annotation_info = extract_java_annotation_info(modifier_child)
+                    if annotation_info.get("name"):
+                        info["annotations"].append(annotation_info)
 
     return info
 
@@ -251,7 +252,7 @@ def extract_java_method_info(method_node: Node) -> JavaMethodInfo:
         - parameters: List of parameter types
         - modifiers: List of access modifiers
         - type_parameters: List of generic type parameters
-        - annotations: List of annotations
+        - annotations: List of annotation metadata dictionaries
     """
     if method_node.type not in ["method_declaration", "constructor_declaration"]:
         return JavaMethodInfo(
@@ -325,9 +326,9 @@ def extract_java_method_info(method_node: Node) -> JavaMethodInfo:
                     if modifier:
                         info["modifiers"].append(modifier)
                 elif modifier_child.type == "annotation":
-                    annotation = safe_decode_text(modifier_child)
-                    if annotation:
-                        info["annotations"].append(annotation)
+                    annotation_info = extract_java_annotation_info(modifier_child)
+                    if annotation_info.get("name"):
+                        info["annotations"].append(annotation_info)
 
     return info
 
@@ -343,7 +344,7 @@ def extract_java_field_info(field_node: Node) -> JavaFieldInfo:
         - name: Field name
         - type: Field type
         - modifiers: List of access modifiers
-        - annotations: List of annotations
+        - annotations: List of annotation metadata dictionaries
     """
     if field_node.type != "field_declaration":
         return JavaFieldInfo(
@@ -390,9 +391,9 @@ def extract_java_field_info(field_node: Node) -> JavaFieldInfo:
                     if modifier:
                         info["modifiers"].append(modifier)
                 elif modifier_child.type == "annotation":
-                    annotation = safe_decode_text(modifier_child)
-                    if annotation:
-                        info["annotations"].append(annotation)
+                    annotation_info = extract_java_annotation_info(modifier_child)
+                    if annotation_info.get("name"):
+                        info["annotations"].append(annotation_info)
 
     return info
 

--- a/codebase_rag/parsers/java_utils.py
+++ b/codebase_rag/parsers/java_utils.py
@@ -19,6 +19,7 @@ class JavaClassInfo(TypedDict):
     interfaces: list[str]
     modifiers: list[str]
     type_parameters: list[str]
+    annotations: list[str]
 
 
 class JavaMethodInfo(TypedDict):
@@ -164,6 +165,7 @@ def extract_java_class_info(class_node: Node) -> JavaClassInfo:
         "interfaces": [],
         "modifiers": [],
         "type_parameters": [],
+        "annotations": [],
     }
 
     # Extract class name
@@ -211,7 +213,7 @@ def extract_java_class_info(class_node: Node) -> JavaClassInfo:
                 if param_name:
                     info["type_parameters"].append(param_name)
 
-    # Extract modifiers using correct tree-sitter traversal
+    # Extract modifiers and annotations using correct tree-sitter traversal
     for child in class_node.children:
         if child.type == "modifiers":
             # Look inside the modifiers node for actual modifier tokens
@@ -227,6 +229,10 @@ def extract_java_class_info(class_node: Node) -> JavaClassInfo:
                     modifier = safe_decode_text(modifier_child)
                     if modifier:
                         info["modifiers"].append(modifier)
+                elif modifier_child.type == "annotation":
+                    annotation = safe_decode_text(modifier_child)
+                    if annotation:
+                        info["annotations"].append(annotation)
 
     return info
 

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -93,7 +93,7 @@ def ingest_method(
     language: str = "",
     extract_decorators_func: Any = None,
     method_qualified_name: str | None = None,
-    method_annotations: list[str] | None = None,
+    method_annotations: list[dict[str, Any]] | None = None,
 ) -> None:
     """Ingest a method node into the graph database.
 
@@ -108,6 +108,7 @@ def ingest_method(
         language: The programming language (used for C++ specific handling).
         extract_decorators_func: Optional function to extract decorators.
         method_qualified_name: Optional pre-computed qualified name to use instead of generating one.
+        method_annotations: Optional list of annotation metadata dictionaries extracted from the method.
     """
     # Extract method name based on language
     if language == "cpp":

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -93,6 +93,7 @@ def ingest_method(
     language: str = "",
     extract_decorators_func: Any = None,
     method_qualified_name: str | None = None,
+    method_annotations: list[str] | None = None,
 ) -> None:
     """Ingest a method node into the graph database.
 
@@ -137,11 +138,14 @@ def ingest_method(
     if extract_decorators_func:
         decorators = extract_decorators_func(method_node)
 
+    annotations = method_annotations if method_annotations is not None else []
+
     # Create method properties
     method_props: dict[str, Any] = {
         "qualified_name": method_qn,
         "name": method_name,
         "decorators": decorators,
+        "annotations": annotations,
         "start_line": method_node.start_point[0] + 1,
         "end_line": method_node.end_point[0] + 1,
         "docstring": get_docstring_func(method_node),


### PR DESCRIPTION
## Summary
- collect annotation metadata from Java class modifiers and attach it to class nodes
- propagate Java method annotations into ingested method properties
- extend Java utilities to decode modifier annotations when extracting class information

## Testing
- pytest codebase_rag/tests/test_java_reflection_annotations.py -k annotations -q

------
https://chatgpt.com/codex/tasks/task_e_68d5a4f38d708323a6f1ecdb90e51257