### PR TITLE
Fix Memgraph preload query for qualified names

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -287,7 +287,7 @@ class GraphUpdater:
             results = self.ingestor.fetch_all(
                 (
                     "MATCH (n) "
-                    "WHERE exists(n.qualified_name) "
+                    "WHERE n.qualified_name IS NOT NULL "
                     "AND any(label IN labels(n) WHERE label IN $allowed_labels) "
                     "RETURN n.qualified_name AS qualified_name, labels(n) AS labels"
                 ),


### PR DESCRIPTION
## Summary
- replace the deprecated `exists(n.qualified_name)` predicate used during preload with a null-check that Memgraph accepts

## Testing
- pytest *(fails: the test suite expects many language-specific tree-sitter parsers to be present and reports 73 failures and 103 skips when only the bundled grammars are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b0b3ff8c83238ea27966bc0f59a5