### PR TITLE
fix(imports): stop Loguru lazy debug from calling ints; precompute preview

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -306,11 +306,12 @@ class ImportProcessor:
                                     preview_items.append(f"... (+{remaining} more)")
                                 return ", ".join(preview_items)
 
-                            logger.opt(lazy=True).debug(
+                            preview = _format_relationship_preview()
+                            logger.debug(
                                 "Created {} unique IMPORTS relationships for {}: {}",
                                 len(relationships_by_module),
                                 module_qn,
-                                _format_relationship_preview,
+                                preview,
                             )
                         except Exception as rel_error:
                             logger.warning(


### PR DESCRIPTION
## Summary
- replace the lazy Loguru debug call with a standard debug that logs a precomputed preview string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ee7466308323a13e395a3de59633