### PR TITLE
Handle Java method references and cross-project calls

### DIFF
--- a/codebase_rag/language_config.py
+++ b/codebase_rag/language_config.py
@@ -251,6 +251,7 @@ LANGUAGE_CONFIGS = {
             name: (identifier) @name) @call
         (object_creation_expression
             type: (type_identifier) @name) @call
+        (method_reference) @call
         """,
     ),
     "cpp": create_lang_config(


### PR DESCRIPTION
## Summary
- extend Java call ingestion to recognize method references and nested lambda invocations when building CALLS relationships
- add cross-project lookup heuristics for Java methods, normalizing signature suffixes to match definitions across projects and enriching pending-call candidates
- cover new scenarios with unit tests for nested lambdas, method references, and cross-project dependency resolution via fully qualified names

## Testing
- `pytest codebase_rag/tests/test_java_method_calls.py codebase_rag/tests/test_cross_project_calls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d715708ab08323879f31e463f44323