### PR TITLE
Restrict cross-project call resolution to Java sources

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -528,18 +528,19 @@ class GraphUpdater:
         for pending in pending_calls:
             candidates = pending.get("candidates") or []
             module_qn = pending.get("module_qn", "")
+            language = pending.get("language")
             resolved: tuple[str, str] | None = None
 
             for candidate in candidates:
                 resolved = call_processor._resolve_registered_qualified_name(
-                    candidate, module_qn
+                    candidate, module_qn, language
                 )
                 if resolved:
                     break
 
             if not resolved and pending.get("call_name"):
                 resolved = call_processor._resolve_registered_qualified_name(
-                    pending["call_name"], module_qn
+                    pending["call_name"], module_qn, language
                 )
 
             if resolved:


### PR DESCRIPTION
## Summary
- limit cross-project definition lookups to Java callers to avoid cross-project edges for other languages
- thread language context through call resolution helpers and persist it with pending calls
- respect the stored language when attempting to resolve pending calls later

## Testing
- pytest codebase_rag/tests/test_cross_project_calls.py *(fails: ModuleNotFoundError: No module named 'loguru')*


------
https://chatgpt.com/codex/tasks/task_e_68d738ab2cf48323a0b56f0f520fa0c0